### PR TITLE
docs: Remove slash(\) and arrange whitespace on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,64 +3,64 @@
 
 ### 링크 리스트 
 
-| No | 페이지 | 내용                                                 | URL                                                   |
+| No | 페이지 | 내용 | URL   |
 |----|----------|----------------------------------------------------|------------------------------------------------------------------------------------------|
-| 1  | 31       | 그림 1\-5 넷플릭스 마감 실적                                 | https://www\.statista\.com/chart/3153/netflix\-subscribers/                                                                                                                           |
-| 2  | 49       | 보쉬 피보탈트래커\(BOSH PivotalTracker\)                   | https://www\.pivotaltracker\.com/n/projects/956238                                                                                                                                    |
-| 3  | 64       | 엘라스틱                                               | http://elastic\.co                                                                                                                                                                    |
-| 4  | 69       | 롤스로이스 무인선박 시스템 유튜브 영상                              | https://www\.youtube\.com/watch?v=vg0A9Ve7SxE&t=2s                                                                                                                                    |
-| 5  | 76       | 그림 2\-8 데이터베이스 클러스터 구현                             | https://docs\.oracle\.com/cd/B28359\_01/server\.111/b28281/architectures\.htm\#i1008366                                                                                               |
-| 6  | 79       | "오라클, EMC, 에뮬렉스 장애 관련 문서"                          | http://www\.oracle\.com/us/technologies/linux/prevent\-silent\-data\-corruption\-1852761\.pdf                                                                                         |
-| 7  | 97       | 넷플릭스 OSS로 공개된 도구들                                  | https://netflix\.github\.io/                                                                                                                                                          |
-| 8  | 109      | 스틸토 프로젝트                                           | https://Steel\-toe\.io                                                                                                                                                                |
-| 9  | 111      | 아카이어스가 제공하는 기능 사용 방법                               | https://github\.com/Netflix/archaius/wiki/Features                                                                                                                                    |
-| 10 | 118      | 넷플릭스 프라나 관련 코드                                     | https://github\.com/Netflix/Prana                                                                                                                                                     |
-| 11 | 118      | 스프링 클라우드 넷플릭스 사이드카                                 | https://cloud\.spring\.io/spring\-cloud\-netflix/multi/multi\_\_polyglot\_support\_with\_sidecar\.html                                                                                |
-| 12 | 122      | 레이가드                                               | https://github\.com/Netflix/Raigad                                                                                                                                                    |
-| 13 | 129      | 넷플릭스의 주울 메니저의 발표\(infoq\.com 계정필요\)                | https://www\.infoq\.com/presentations/netflix\-gateway\-zuul?utm\_source=infoq&utm\_medium=QCon\_EarlyAccessVideos&utm\_campaign=SpringOnePlatform2016                                |
-| 14 | 130      | 넷플릭스가 공개한 주울에 대한 정보                                | "https://github\.com/Netflix/zuul/wiki                                                                                                                                                |
-| 15 | 141      | 스프링 클라우드 넷플릭스 리본                                   | https://spring\.io/guides/gs/client\-side\-load\-balancing/                                                                                                                           |
-| 16 | 145      | 아틀라스 문서                                            | http://netflix\.github\.io/spectator/en/latest/intro/conventions/                                                                                                                     |
-| 17 | 146      | 그림 3\-20 아틀라스 UI                                   | https://www\.slideshare\.net/brendangregg/monitorama\-2015\-netflix\-instance\-analysis                                                                                               |
-| 18 | 151      | 아틀라스와 모니터링                                         | https://docs\.spring\.io/spring\-boot/docs/current/reference/html/productionready\-metrics\.html                                                                                      |
-| 19 | 155      | 네플릭스 리전 장애 테스트 유튜브 영상                              | https://youtu\.be/ftIsVoJNCHk                                                                                                                                                         |
-| 20 | 155      | 깃허브의 Vizceralexample                               | https://github\.com/Netflix/vizceral\-example                                                                                                                                         |
-| 21 | 158      | 케타마 알고리즘                                           | "https://medium\.com/@dgryski/consistent\-hashing\-algorithmic\-tradeoffs\-ef\-6b8e2fcae8 https://www\.metabrew\.com/article/libketama\-consistent\-hashing\-algo\-memcached\-clients |
-| 22 | 173      | EVCache 관련 발표 영상                                   | https://www\.youtube\.com/watch?v=Ve7ueEYC4TM                                                                                                                                         |
-| 23 | 178      | 마틴 파울러 닷컴                                          | https://martinfowler\.com/bliki/CircuitBreaker\.html                                                                                                                                  |
-| 24 | 181      | 아파치 스파크가 카오스 몽키 실험에서도 살아남을 수 있을까?                  | https://medium\.com/netflix\-techblog/can\-spark\-streaming\-survive\-chaos\-monkey\-b66482c4924a                                                                                     |
-| 25 | 181      | 그림 3\-38 넷플릭스 카프카와 카오스 엔지니어링                       | https://medium\.com/netflix\-techblog/can\-spark\-streaming\-survive\-chaos\-monkey\-b66482c4924a                                                                                     |
-| 26 | 184      | "아마존웹서비스의 S3가 다운되었음에도 불구하고, 왜 넷플릭스 서비스에는 문제가 없었는가" | https://www\.networkworld\.com/article/3178076/cloud\-computing/why\-netflix\-didnt\-sink\-whenamazon\-s3\-went\-down\.html                                                           |
-| 27 | 186      | "그림 3\-41 연속 개선 및 배포 파이프라인 이미지, Concourse CI"      | https://github\.com/starkandwayne/pipeline\-templates                                                                                                                                 |
-| 28 | 187      | 그림 3\-42 컨커스 도구에서 컨테이너 이미지 사용                      | https://concoursetutorial\.com/miscellaneous/docker\-images/                                                                                                                          |
-| 29 | 191      | 타이터스                                               | https://netflix\.github\.io/titus/                                                                                                                                                    |
-| 30 | 193      | 타이터스 마스터와 게이트웨이 준비                                 | https://netflix\.github\.io/titus/install/master/                                                                                                                                     |
-| 31 | 193      | 타이터스 에이전트                                          | https://netflix\.github\.io/titus/install/agent/                                                                                                                                      |
-| 32 | 195      | AWS Instance Metadata and User data                | https://docs\.aws\.amazon\.com/ko\_kr/AWSEC2/latest/UserGuide/ec2\-instance\-metadata\.html                                                                                           |
-| 33 | 199      | 넷플릭스의 자유와 책임 \_ 스마트스터디                             | https://www\.slideshare\.net/watchncompass/freedom\-responsibility\-culture                                                                                                           |
-| 34 | 200      | 넷플릭스의 자유와 책임 \_ 스마트스터디\(비속어 번역본\)                  | https://www\.slideshare\.net/evoka/freedom\-responsibility\-culture\-49207219                                                                                                         |
-| 35 | 209      | 넷플릭스의 일하는 방법에 대한 가이드라인                             | https://jobs\.netflix\.com/culture                                                                                                                                                    |
-| 36 | 210      | 아마존 운영 가이드                                         | https://www\.amazon\.jobs/principles                                                                                                                                                  |
-| 37 | 222      | 피보탈 오픈소스 포트폴리오                                     | https://pivotal\.io/products                                                                                                                                                          |
-| 38 | 222      | 피보탈 오픈소스                                           | https://pivotal\.io/open\-source                                                                                                                                                      |
-| 39 | 223      | 피보탈 트래커                                            | https://www\.pivotaltracker\.com                                                                                                                                                      |
-| 40 | 249      | 스프링 부트                                             | http://start\.spring\.io                                                                                                                                                              |
-| 41 | 254      | 스프링 프로젝트                                           | https://spring\.io/projects                                                                                                                                                           |
-| 42 | 255      | 스프링 프레임워크                                          | http://projects\.spring\.io/spring\-framework                                                                                                                                         |
-| 43 | 255      | 스프링 프로젝트 자세한 기능                                    | https://docs\.spring\.io/spring/docs/current/spring\-framework\-reference/index\.html                                                                                                 |
-| 44 | 255      | 스프링 부트 프로젝트                                        | http://projects\.spring\.io/spring\-boot                                                                                                                                              |
-| 45 | 249      | 스프링 부트                                             | http://start\.spring\.io                                                                                                                                                              |
-| 46 | 256      | 스프링 클라우드                                           | http://projects\.spring\.io/spring\-cloud                                                                                                                                             |
-| 47 | 258      | Spring Cloud Stream App Starters                   | http://cloud\.spring\.io/springcloud\-stream\-app\-starters                                                                                                                           |
-| 48 | 258      | Spring Cloud for Amazon Web Services               | https://cloud\.spring\.io/spring\-cloud\-aws                                                                                                                                          |
-| 49 | 259, 263 | 피보탈 트래커                                            | http://www\.pivotaltracker\.com                                                                                                                                                       |
-| 50 | 264      | 피보탈 컨커스                                            | http://concourse\.ci                                                                                                                                                                  |
-| 51 | 267      | 피보탈 클라우드 파운드리                                      | http://pcfdev\.io https://run\.pivotal\.io                                                                                                                                            |
-| 52 | 268      | 피보탈 클라우드 파운드리 다운로드                                 | http://network\.pivotal\.io                                                                                                                                                           |
-| 53 | 268      | PCFDEV                                             | http://pcfdev\.io                                                                                                                                                                     |
-| 54 | 273      | 그림 4\-13 넷플릭스의 플랫폼 팀                               | https://www\.nginx\.com/blog/adopting\-microservices\-at\-netflix\-lessons\-for\-team\-and\-process\-design/                                                                          |
-| 55 | 277      | 마이크로서비스를 현미경으로 보기                                  | https://medium\.com/netflix\-techblog/a\-microscope\-on\-microservices\-923b906103f4                                                                                                  |
-| 56 | 280      | 오픈트레이싱                                             | https://opentracing\.io  https://github\.com/opentracing                                                                                                                              |
-| 57 | 280      | Resilience4j                                       | https://resilience4j\.readme\.io/docs                                                                                                                                                 |
-| 58 | 286      | 데이터 처리를 위한 카프카 스트림 생성 및 클러스터에 카오스 엔지니어링 적용하는 과정    | https://medium\.com/netflix\-techblog/can\-sparkstreaming\-survive\-chaos\-monkey\-b66482c4924a                                                                                       |
-| 59 | 287      | 카오스 몽키 스프링 부트                                      | https://codecentric\.github\.io/chaos\-monkey\-spring\-boot/                                                                                                                          |
+| 1  | 31 | 그림 1-5 넷플릭스 마감 실적   | https://www.statista.com/chart/3153/netflix-subscribers/   |
+| 2  | 49 | 보쉬 피보탈트래커(BOSH PivotalTracker) | https://www.pivotaltracker.com/n/projects/956238|
+| 3  | 64 | 엘라스틱     | http://elastic.co  |
+| 4  | 69 | 롤스로이스 무인선박 시스템 유튜브 영상| https://www.youtube.com/watch?v=vg0A9Ve7SxE&t=2s|
+| 5  | 76 | 그림 2-8 데이터베이스 클러스터 구현     | https://docs.oracle.com/cd/B28359_01/server.111/b28281/architectures.htm#i1008366     |
+| 6  | 79 | "오라클, EMC, 에뮬렉스 장애 관련 문서"  | http://www.oracle.com/us/technologies/linux/prevent-silent-data-corruption-1852761.pdf     |
+| 7  | 97 | 넷플릭스 OSS로 공개된 도구들    | https://netflix.github.io/    |
+| 8  | 109| 스틸토 프로젝트 | https://Steel-toe.io    |
+| 9  | 111| 아카이어스가 제공하는 기능 사용 방법 | https://github.com/Netflix/archaius/wiki/Features|
+| 10 | 118| 넷플릭스 프라나 관련 코드 | https://github.com/Netflix/Prana     |
+| 11 | 118| 스프링 클라우드 넷플릭스 사이드카   | https://cloud.spring.io/spring-cloud-netflix/multi/multi__polyglot_support_with_sidecar.html  |
+| 12 | 122| 레이가드     | https://github.com/Netflix/Raigad    |
+| 13 | 129| 넷플릭스의 주울 메니저의 발표(infoq.com 계정필요)    | https://www.infoq.com/presentations/netflix-gateway-zuul?utm_source=infoq&utm_medium=QCon_EarlyAccessVideos&utm_campaign=SpringOnePlatform2016  |
+| 14 | 130| 넷플릭스가 공개한 주울에 대한 정보  | https://github.com/Netflix/zuul/wiki|
+| 15 | 141| 스프링 클라우드 넷플릭스 리본     | https://spring.io/guides/gs/client-side-load-balancing/   |
+| 16 | 145| 아틀라스 문서  | http://netflix.github.io/spectator/en/latest/intro/conventions/   |
+| 17 | 146| 그림 3-20 아틀라스 UI     | https://www.slideshare.net/brendangregg/monitorama-2015-netflix-instance-analysis     |
+| 18 | 151| 아틀라스와 모니터링     | https://docs.spring.io/spring-boot/docs/current/reference/html/productionready-metrics.html  |
+| 19 | 155| 네플릭스 리전 장애 테스트 유튜브 영상| https://youtu.be/ftIsVoJNCHk   |
+| 20 | 155| 깃허브의 Vizceralexample | https://github.com/Netflix/vizceral-example     |
+| 21 | 158| 케타마 알고리즘 | https://medium.com/@dgryski/consistent-hashing-algorithmic-tradeoffs-ef-6b8e2fcae8 https://www.metabrew.com/article/libketama-consistent-hashing-algo-memcached-clients |
+| 22 | 173| EVCache 관련 발표 영상     | https://www.youtube.com/watch?v=Ve7ueEYC4TM     |
+| 23 | 178| 마틴 파울러 닷컴| https://martinfowler.com/bliki/CircuitBreaker.html    |
+| 24 | 181| 아파치 스파크가 카오스 몽키 실험에서도 살아남을 수 있을까?| https://medium.com/netflix-techblog/can-spark-streaming-survive-chaos-monkey-b66482c4924a |
+| 25 | 181| 그림 3-38 넷플릭스 카프카와 카오스 엔지니어링     | https://medium.com/netflix-techblog/can-spark-streaming-survive-chaos-monkey-b66482c4924a |
+| 26 | 184| "아마존웹서비스의 S3가 다운되었음에도 불구하고, 왜 넷플릭스 서비스에는 문제가 없었는가" | https://www.networkworld.com/article/3178076/cloud-computing/why-netflix-didnt-sink-whenamazon-s3-went-down.html     |
+| 27 | 186| "그림 3-41 연속 개선 및 배포 파이프라인 이미지, Concourse CI"| https://github.com/starkandwayne/pipeline-templates   |
+| 28 | 187| 그림 3-42 컨커스 도구에서 컨테이너 이미지 사용    | https://concoursetutorial.com/miscellaneous/docker-images/  |
+| 29 | 191| 타이터스     | https://netflix.github.io/titus/    |
+| 30 | 193| 타이터스 마스터와 게이트웨이 준비   | https://netflix.github.io/titus/install/master/ |
+| 31 | 193| 타이터스 에이전트| https://netflix.github.io/titus/install/agent/  |
+| 32 | 195| AWS Instance Metadata and User data    | https://docs.aws.amazon.com/ko_kr/AWSEC2/latest/UserGuide/ec2-instance-metadata.html |
+| 33 | 199| 넷플릭스의 자유와 책임 _ 스마트스터디     | https://www.slideshare.net/watchncompass/freedom-responsibility-culture     |
+| 34 | 200| 넷플릭스의 자유와 책임 _ 스마트스터디(비속어 번역본)| https://www.slideshare.net/evoka/freedom-responsibility-culture-49207219   |
+| 35 | 209| 넷플릭스의 일하는 방법에 대한 가이드라인     | https://jobs.netflix.com/culture    |
+| 36 | 210| 아마존 운영 가이드     | https://www.amazon.jobs/principles  |
+| 37 | 222| 피보탈 오픈소스 포트폴리오 | https://pivotal.io/products    |
+| 38 | 222| 피보탈 오픈소스 | https://pivotal.io/open-source|
+| 39 | 223| 피보탈 트래커  | https://www.pivotaltracker.com|
+| 40 | 249| 스프링 부트   | http://start.spring.io  |
+| 41 | 254| 스프링 프로젝트 | https://spring.io/projects     |
+| 42 | 255| 스프링 프레임워크| http://projects.spring.io/spring-framework     |
+| 43 | 255| 스프링 프로젝트 자세한 기능| https://docs.spring.io/spring/docs/current/spring-framework-reference/index.html |
+| 44 | 255| 스프링 부트 프로젝트    | http://projects.spring.io/spring-boot    |
+| 45 | 249| 스프링 부트   | http://start.spring.io  |
+| 46 | 256| 스프링 클라우드 | http://projects.spring.io/spring-cloud   |
+| 47 | 258| Spring Cloud Stream App Starters | http://cloud.spring.io/springcloud-stream-app-starters   |
+| 48 | 258| Spring Cloud for Amazon Web Services   | https://cloud.spring.io/spring-cloud-aws|
+| 49 | 259, 263 | 피보탈 트래커  | http://www.pivotaltracker.com |
+| 50 | 264| 피보탈 컨커스  | http://concourse.ci|
+| 51 | 267| 피보탈 클라우드 파운드리  | http://pcfdev.io https://run.pivotal.io  |
+| 52 | 268| 피보탈 클라우드 파운드리 다운로드   | http://network.pivotal.io     |
+| 53 | 268| PCFDEV   | http://pcfdev.io   |
+| 54 | 273| 그림 4-13 넷플릭스의 플랫폼 팀 | https://www.nginx.com/blog/adopting-microservices-at-netflix-lessons-for-team-and-process-design/  |
+| 55 | 277| 마이크로서비스를 현미경으로 보기    | https://medium.com/netflix-techblog/a-microscope-on-microservices-923b906103f4  |
+| 56 | 280| 오픈트레이싱   | https://opentracing.io  https://github.com/opentracing|
+| 57 | 280| Resilience4j   | https://resilience4j.readme.io/docs |
+| 58 | 286| 데이터 처리를 위한 카프카 스트림 생성 및 클러스터에 카오스 엔지니어링 적용하는 과정    | https://medium.com/netflix-techblog/can-sparkstreaming-survive-chaos-monkey-b66482c4924a   |
+| 59 | 287| 카오스 몽키 스프링 부트  | https://codecentric.github.io/chaos-monkey-spring-boot/  |


### PR DESCRIPTION
The hyperlink didn't work because of the slash.